### PR TITLE
Use unused import warning as default

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,11 +57,8 @@ object Build extends Build {
     "-deprecation",
     "-language:_",
     "-Xlint",
-    "-Xlog-reflective-calls"
-  )
-
-  val fussyScalacOptions = basicScalacOptions ++ Seq(
-    "-Ywarn-unused",
+    "-Xlog-reflective-calls",
+        "-Ywarn-unused",
     "-Ywarn-unused-import"
   )
 }


### PR DESCRIPTION
Why not directly check on unused imports. Then you would have noticed that /StaminaAkkaSerializer.scala:3: Unused import
[
