### PR TITLE
Move to the latest scalariform plugin

### DIFF
--- a/project/Formatting.scala
+++ b/project/Formatting.scala
@@ -15,6 +15,5 @@ object Formatting {
       .setPreference(AlignSingleLineCaseStatements, true)
       .setPreference(AlignSingleLineCaseStatements.MaxArrowIndent, 90)
       .setPreference(DoubleIndentClassDeclaration, true)
-      .setPreference(PreserveDanglingCloseParenthesis, true)
       .setPreference(RewriteArrowSymbols, true)
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.5.1")


### PR DESCRIPTION
We're now using the community supported one instead of the dead official one. The new site is here:

https://github.com/daniel-trinh/sbt-scalariform

Fixes #37
