### PR TITLE
Make exception overridable

### DIFF
--- a/stamina-core/src/main/scala/stamina/StaminaAkkaSerializer.scala
+++ b/stamina-core/src/main/scala/stamina/StaminaAkkaSerializer.scala
@@ -19,10 +19,12 @@ abstract class StaminaAkkaSerializer private[stamina] (persisters: Persisters, c
    * @throws UnregisteredTypeException when the specified object is not supported by the persisters.
    */
   def toBinary(obj: AnyRef): Array[Byte] = {
-    if (!persisters.canPersist(obj)) throw UnregisteredTypeException(obj)
+    if (!persisters.canPersist(obj)) throw cannotPersistError(obj)
 
     codec.writePersisted(persisters.persist(obj))
   }
+
+  def cannotPersistError(obj: AnyRef): RuntimeException = UnregisteredTypeException(obj)
 
   /**
    * @throws UnsupportedDataException when the persisted key and/or version is not supported.


### PR DESCRIPTION
I have a slightly exotic usecase where I would like to customise the error being thrown by the akka serializer.

Right now I have to override more than I actually need to. If this PR is accepted I don't have do that anymore but can override just the single method that produces the error.

Thanks for stamina!