### PR TITLE
Delete temporary testkit resource files if they already exist

### DIFF
--- a/stamina-testkit/src/main/scala/stamina/testkit/StaminaTestKit.scala
+++ b/stamina-testkit/src/main/scala/stamina/testkit/StaminaTestKit.scala
@@ -81,7 +81,7 @@ trait StaminaTestKit { self: org.scalatest.WordSpecLike ⇒
     private def saveByteArrayToTargetSerializationDirectory(bytes: Array[Byte], key: String, version: Int, sampleId: String) = {
       import java.nio.file._
       val path = Paths.get(targetDirectoryForExampleSerializations, filename(key, version, sampleId))
-      Files.write(path, base64.Encode(bytes), StandardOpenOption.CREATE)
+      Files.write(path, base64.Encode(bytes), StandardOpenOption.TRUNCATE_EXISTING)
       path.toAbsolutePath
     }
 


### PR DESCRIPTION
I've hit this very confusing edge case in stamina testkit where I was continuously writing slightly modified versions of the binary data on disk and then copying them into my project.

As it turns out `Files.write` does not overwrite the file but fills it with new data up until the end of the binary stream. If the file used to contain more bytes then the temp file contains the current bytes plus the end of the previous file. This then causes the Json parser to choke as there are extra characters at the end of the file.