### PR TITLE
ISSUE-52 

### DIFF
--- a/stamina-testkit/src/main/scala/stamina/testkit/StaminaTestKit.scala
+++ b/stamina-testkit/src/main/scala/stamina/testkit/StaminaTestKit.scala
@@ -7,7 +7,7 @@ trait StaminaTestKit { self: org.scalatest.WordSpecLike ⇒
 
   val defaultSampleId = "default"
   case class PersistableSample(sampleId: String, persistable: AnyRef, description: Option[String]) {
-    override def toString = persistable.getClass.getSimpleName + description.map(" " + _).getOrElse("")
+    override def toString = SimpleClassNameExtractor(persistable.getClass) + description.map(" " + _).getOrElse("")
   }
 
   def sample(persistable: AnyRef) = new PersistableSample(defaultSampleId, persistable, None)
@@ -89,5 +89,11 @@ trait StaminaTestKit { self: org.scalatest.WordSpecLike ⇒
 
     val targetDirectoryForExampleSerializations = System.getProperty("java.io.tmpdir")
     val serializedObjectsPackage = "serialization"
+  }
+
+  // Workaround for https://issues.scala-lang.org/browse/SI-2034
+  private[testkit] object SimpleClassNameExtractor {
+    def extractSimpleClassName(input: String) = input.split("\\.").last.split("\\$").last
+    def apply[T](input: Class[T]): String = extractSimpleClassName(input.getName)
   }
 }

--- a/stamina-testkit/src/test/scala/stamina/testkit/ScalatestTestGenerationSpec.scala
+++ b/stamina-testkit/src/test/scala/stamina/testkit/ScalatestTestGenerationSpec.scala
@@ -22,7 +22,8 @@ class ScalatestTestGenerationSpec extends StaminaTestKitSpec {
       "TestDomainSerialization" should {
         persisters.generateTestsFor(
           sample(item1),
-          sample("failing-item-2", item2)
+          sample("failing-item-2", item2),
+          sample("3-level-nested-structure", Level1.Level2.Level3)
         )
       }
     }

--- a/stamina-testkit/src/test/scala/stamina/testkit/TestDomain.scala
+++ b/stamina-testkit/src/test/scala/stamina/testkit/TestDomain.scala
@@ -8,6 +8,8 @@ object TestDomain {
   case class Cart(id: CartId, items: List[Item])
   case class CartCreated(cart: Cart)
 
+  object Level1 { object Level2 { case object Level3 } }
+
   val item1 = Item(1, "Wonka Bar")
   val item2 = Item(2, "Everlasting Gobstopper")
   val cart = Cart(1, List(item1, item2))


### PR DESCRIPTION
Fixes https://github.com/scalapenos/stamina/issues/52
Workaround for scala bug [SI-2034](https://issues.scala-lang.org/browse/SI-2034) that was causing `java.langInternalError: Malformed class name`