### PR TITLE
Missing sample for the latest version is not created

### DIFF
--- a/stamina-testkit/src/main/scala/stamina/testkit/StaminaTestKit.scala
+++ b/stamina-testkit/src/main/scala/stamina/testkit/StaminaTestKit.scala
@@ -84,7 +84,7 @@ trait StaminaTestKit { self: org.scalatest.WordSpecLike ⇒
     private def saveByteArrayToTargetSerializationDirectory(bytes: Array[Byte], key: String, version: Int, sampleId: String) = {
       import java.nio.file._
       val path = Paths.get(targetDirectoryForExampleSerializations, filename(key, version, sampleId))
-      Files.write(path, encodeBase64(bytes), StandardOpenOption.TRUNCATE_EXISTING)
+      Files.write(path, encodeBase64(bytes), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
       path.toAbsolutePath
     }
 

--- a/stamina-testkit/src/test/scala/stamina/testkit/ScalatestTestGenerationSpec.scala
+++ b/stamina-testkit/src/test/scala/stamina/testkit/ScalatestTestGenerationSpec.scala
@@ -1,6 +1,8 @@
 package stamina
 package testkit
 
+import java.io.File
+
 import org.scalatest._
 import org.scalatest.events._
 import org.scalatest.matchers.{BePropertyMatchResult, BePropertyMatcher}
@@ -55,6 +57,12 @@ class ScalatestTestGenerationSpec extends StaminaTestKitSpec {
         val myRep = execSpec(spec)
         val Some(res) = myRep.findResultEvent("TestDomainSerialization should deserialize the stored serialized form of Item failing-item-2 version 1")
         res should be(anInstanceOf[TestFailed])
+      }
+
+      "creates missing sample file in /tmp directory for the newest version" in {
+        val myRep = execSpec(spec)
+        myRep.testFailedEventsReceived.find(_.message.startsWith("You appear to have added a new serialization sample to the stamina persisters' test")).value
+        new File(System.getProperty("java.io.tmpdir"), "/item1-v2-default") should exist
       }
     }
 


### PR DESCRIPTION
https://github.com/scalapenos/stamina/pull/60 introduces a bug: when a sample doesn't exist, test fails with uncaught `NoSuchFileException` thrown by `Files.write` function.