### PR TITLE
Add possibility to unpersist data one generation younger

### DIFF
--- a/stamina-core/src/test/scala/stamina/migrations/MigratorSpec.scala
+++ b/stamina-core/src/test/scala/stamina/migrations/MigratorSpec.scala
@@ -1,0 +1,118 @@
+package stamina.migrations
+
+import stamina._
+
+class MigratorSpec extends StaminaSpec {
+
+  val mV3WithBackwardMigration: Migrator[String, V3] =
+    from[String, V1]
+      .to[V2](_ + "V2")
+      .to[V3](_ + "V3")
+      .backFrom[V4](_.replace("V4", ""))
+
+  val mV3WithIgnoredBackwardMigration: Migrator[String, V3] =
+    from[String, V1]
+      .to[V2](_ + "V2")
+      .backFrom[V3](_ + "this should not be added")
+      .to[V3](_ + "V3")
+
+  val mV1WithBackwardMigration: Migrator[String, V1] =
+    from[String, V1]
+      .backFrom[V2](_.replace("V2", ""))
+
+  "Migrator with backward migration" should {
+    "be able to migrate" when {
+      "migration is from V1" in {
+        mV3WithBackwardMigration.canMigrate(1) shouldBe true
+      }
+
+      "migration is from V2" in {
+        mV3WithBackwardMigration.canMigrate(2) shouldBe true
+      }
+
+      "migration is from V3 (identity)" in {
+        mV3WithBackwardMigration.canMigrate(3) shouldBe true
+      }
+
+      "migration is from V4 (backward migration)" in {
+        mV3WithBackwardMigration.canMigrate(4) shouldBe true
+      }
+    }
+
+    "not be able to migrate" when {
+      "migration is from V5" in {
+        mV3WithBackwardMigration.canMigrate(5) shouldBe false
+      }
+    }
+
+    "migrate forward" when {
+      "migration is from V1" in {
+        mV3WithBackwardMigration.migrate("V1", 1) shouldBe "V1V2V3"
+      }
+
+      "migration is from V2" in {
+        mV3WithBackwardMigration.migrate("V1V2", 2) shouldBe "V1V2V3"
+      }
+
+      "migration is from V3" in {
+        mV3WithBackwardMigration.migrate("V1V2V3", 3) shouldBe "V1V2V3"
+      }
+    }
+
+    "migrate backward" when {
+      "migration is from V4" in {
+        mV3WithBackwardMigration.migrate("V1V2V3V4", 4) shouldBe "V1V2V3"
+      }
+    }
+  }
+
+  "Migrator with ignored backward migration" should {
+    "be able to migrate" when {
+      "migration is from V1" in {
+        mV3WithIgnoredBackwardMigration.canMigrate(1) shouldBe true
+      }
+
+      "migration is from V2" in {
+        mV3WithIgnoredBackwardMigration.canMigrate(2) shouldBe true
+      }
+
+      "migration is from V3 (identity)" in {
+        mV3WithIgnoredBackwardMigration.canMigrate(3) shouldBe true
+      }
+    }
+
+    "not be able to migrate" when {
+      "migration is from V4" in {
+        mV3WithIgnoredBackwardMigration.canMigrate(4) shouldBe false
+      }
+    }
+
+    "migrate" when {
+      "migration is from V1" in {
+        mV3WithIgnoredBackwardMigration.migrate("V1", 1) shouldBe "V1V2V3"
+      }
+
+      "migration is from V2" in {
+        mV3WithIgnoredBackwardMigration.migrate("V1V2", 2) shouldBe "V1V2V3"
+      }
+
+      "migration is from V3" in {
+        mV3WithIgnoredBackwardMigration.migrate("V1V2V3", 3) shouldBe "V1V2V3"
+      }
+    }
+  }
+
+  "Migrator V1 with backward migration" should {
+    "be able to migrate" when {
+      "migration is from V2" in {
+        mV1WithBackwardMigration.canMigrate(2) shouldBe true
+      }
+    }
+
+    "migrate" when {
+      "migration is from V2" in {
+        mV1WithBackwardMigration.migrate("V1V2", 2) shouldBe "V1"
+      }
+    }
+  }
+}

--- a/stamina-json/src/test/scala/stamina/json/JsonPersisterSpec.scala
+++ b/stamina-json/src/test/scala/stamina/json/JsonPersisterSpec.scala
@@ -2,28 +2,54 @@ package stamina
 package json
 
 class JsonPersisterSpec extends StaminaJsonSpec {
+
   import JsonTestDomain._
-  import spray.json.lenses.JsonLenses._
   import fommil.sjs.FamilyFormats._
+  import spray.json.lenses.JsonLenses._
 
   val v1CartCreatedPersister = persister[CartCreatedV1]("cart-created")
+
+  val v1CartCreatedPersisterWithBackwardMigration = persister[CartCreatedV1](
+    "cart-created",
+    from[V1].backFrom[V2](identity)
+  )
 
   val v2CartCreatedPersister = persister[CartCreatedV2, V2](
     "cart-created",
     from[V1].to[V2](_.update('cart / 'items / * / 'price ! set[Int](1000)))
   )
 
-  val v3CartCreatedPersister = persister[CartCreatedV3, V3](
-    "cart-created",
+  val migratorV3 =
     from[V1]
       .to[V2](_.update('cart / 'items / * / 'price ! set[Int](1000)))
       .to[V3](_.update('timestamp ! set[Long](System.currentTimeMillis - 3600000L)))
+
+  val v3CartCreatedPersister = persister[CartCreatedV3, V3](
+    "cart-created",
+    migratorV3
+  )
+
+  val v3CartCreatedPersisterWithBackwardMigration = persister[CartCreatedV3, V3](
+    "cart-created",
+    migratorV3
+      .backFrom[V4](_.update(('cart / 'items / * / 'name.?) ! setOrUpdateField[String]("unknown")(identity)))
+  )
+
+  val v4SimpleCartCreatedPersister = persister[CartCreatedV4, V4](
+    "cart-created",
+    from[V1].to[V2](identity).to[V3](identity).to[V4](identity)
   )
 
   "V1 persisters produced by SprayJsonPersister" should {
     "correctly persist and unpersist domain events " in {
       import v1CartCreatedPersister._
       unpersist(persist(v1CartCreated)) should equal(v1CartCreated)
+    }
+
+    "fail to unpersist V2 domain events" in {
+      val v2Persisted = v2CartCreatedPersister.persist(v2CartCreated)
+      val e = intercept[IllegalArgumentException](v1CartCreatedPersister.unpersist(v2Persisted))
+      e.getMessage.contains("cannot unpersist data") shouldBe true
     }
   }
 
@@ -56,6 +82,58 @@ class JsonPersisterSpec extends StaminaJsonSpec {
 
       v1Unpersisted.cart.items.map(_.price).toSet should equal(Set(1000))
       v2Unpersisted.timestamp should (be > 0L and be < System.currentTimeMillis)
+    }
+
+    "fail to migrate and unpersist V4 domain events" in {
+      val v4Persisted = v4SimpleCartCreatedPersister.persist(v4CartCreated)
+      val e = intercept[IllegalArgumentException](v3CartCreatedPersister.unpersist(v4Persisted))
+      e.getMessage.contains("cannot unpersist data") shouldBe true
+    }
+  }
+
+  "V1 persisters with migrators with backward migrations produced by SprayJsonPersister" should {
+    "correctly persist and unpersist domain events" in {
+      import v1CartCreatedPersisterWithBackwardMigration._
+      unpersist(persist(v1CartCreated)) should equal(v1CartCreated)
+    }
+
+    "correctly migrte and unpersist V2 domain events" in {
+      val v2Persister = v2CartCreatedPersister.persist(v2CartCreated)
+      val v1UnpersistedFromV2 = v1CartCreatedPersisterWithBackwardMigration.unpersist(v2Persister)
+      v1UnpersistedFromV2 should equal(v1CartCreated)
+    }
+  }
+
+  "V4 dummy persister" should {
+    "correctly persist and unpersist domain events " in {
+      import v4SimpleCartCreatedPersister._
+      unpersist(persist(v4CartCreated)) should equal(v4CartCreated)
+    }
+  }
+
+  "V3 persisters with backward migrations and migrators produced by SprayJsonPersister" should {
+    "correctly persist and unpersist domain events " in {
+      import v3CartCreatedPersister._
+      unpersist(persist(v3CartCreated)) should equal(v3CartCreated)
+    }
+
+    "correctly migrate and unpersist V1 domain events" in {
+      val v1Persisted = v1CartCreatedPersister.persist(v1CartCreated)
+      val v2Persisted = v2CartCreatedPersister.persist(v2CartCreated)
+
+      val v1Unpersisted = v3CartCreatedPersisterWithBackwardMigration.unpersist(v1Persisted)
+      val v2Unpersisted = v3CartCreatedPersisterWithBackwardMigration.unpersist(v2Persisted)
+
+      v1Unpersisted.cart.items.map(_.price).toSet should equal(Set(1000))
+      v2Unpersisted.timestamp should (be > 0L and be < System.currentTimeMillis)
+    }
+
+    "correctly migrate and unpersist V4 domain events setting default value for removed field" in {
+      val v4Persisted = v4SimpleCartCreatedPersister.persist(v4CartCreated)
+
+      val v3UnpersistedFromV4 = v3CartCreatedPersisterWithBackwardMigration.unpersist(v4Persisted)
+
+      v3UnpersistedFromV4.cart.items.map(_.name) should equal(List("Wonka Bar", "unknown"))
     }
   }
 }

--- a/stamina-json/src/test/scala/stamina/json/JsonTestDomain.scala
+++ b/stamina-json/src/test/scala/stamina/json/JsonTestDomain.scala
@@ -42,4 +42,17 @@ object JsonTestDomain {
   val v3Item2 = ItemV3(2, "Everlasting Gobstopper", 489)
   val v3Cart = CartV3(1, List(v3Item1, v3Item2))
   val v3CartCreated = CartCreatedV3(v3Cart, System.currentTimeMillis)
+
+  // ==========================================================================
+  // V4
+  // ==========================================================================
+
+  case class ItemV4(id: ItemId, name: Option[String], price: Int)
+  case class CartV4(id: CartId, items: List[ItemV4])
+  case class CartCreatedV4(cart: CartV4, timestamp: Long)
+
+  val v4Item1 = ItemV4(1, Some("Wonka Bar"), 500)
+  val v4Item2 = ItemV4(2, None, 489)
+  val v4Cart = CartV4(1, List(v4Item1, v4Item2))
+  val v4CartCreated = CartCreatedV4(v4Cart, System.currentTimeMillis)
 }


### PR DESCRIPTION
#57 
Allow `Persister` and `Migrator` with version `V` to unpersist data that have not only version `X <= V` but also `V + 1`.
Possible use-case scenario described in https://github.com/scalapenos/stamina/issues/57#issuecomment-313212248